### PR TITLE
Change shell interpreter to bash

### DIFF
--- a/build64.sh
+++ b/build64.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #./build64.sh [n.n.n n]
 #CMAKE=/path-to/Cmake/bin/cmake ENABLE_TESTING=1 ./build64.sh [n.n.n n]
 


### PR DESCRIPTION
## Description
This file uses some purely bash syntax like `function` and will not execute correctly on a system with a different interpreter aliased to `/bin/sh`

## Motivation and Context
Systems like Ubuntu don't have `/bin/bash` aliased to `/bin/sh`

## Testing
./build64.sh now executes without error

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## License
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
