### PR TITLE
fix: add Servername as a recognized hostname keyword

### DIFF
--- a/src/odbc/rsodbc/rsconnect.cpp
+++ b/src/odbc/rsodbc/rsconnect.cpp
@@ -2247,7 +2247,8 @@ int RS_CONN_INFO::parseConnectString(char *szConnStrIn, size_t cbConnStrIn, int 
         * Store the value, if same param is not repeated.
         */
         if (_stricmp(pname, RS_HOST_NAME) == 0 ||
-            _stricmp(pname, RS_HOST) == 0 || _stricmp(pname, RS_SERVER) == 0) {
+            _stricmp(pname, RS_HOST) == 0 || _stricmp(pname, RS_SERVER) == 0 ||
+            _stricmp(pname, RS_SERVER_NAME) == 0) {
           pConnectProps->iHostNameKeyWordType =
               (_stricmp(pname, RS_HOST_NAME) == 0) ? LONG_NAME_KEYWORD
                                                    : SHORT_NAME_KEYWORD;
@@ -3116,6 +3117,8 @@ void RS_CONN_INFO::readMoreConnectPropsFromRegistry(int readUser)
               RS_SQLGetPrivateProfileString(pConnectProps->szDSN, RS_HOST, "", pConnectProps->szHost, MAX_IDEN_LEN, ODBC_INI);
               if(pConnectProps->szHost[0] == '\0')
                 RS_SQLGetPrivateProfileString(pConnectProps->szDSN, RS_SERVER, "", pConnectProps->szHost, MAX_IDEN_LEN, ODBC_INI);
+              if(pConnectProps->szHost[0] == '\0')
+                RS_SQLGetPrivateProfileString(pConnectProps->szDSN, RS_SERVER_NAME, "", pConnectProps->szHost, MAX_IDEN_LEN, ODBC_INI);
             }
         }
 

--- a/src/odbc/rsodbc/rsodbc.h
+++ b/src/odbc/rsodbc/rsodbc.h
@@ -1147,6 +1147,7 @@ struct SHOWPROCEDURESFUNCTIONSResult {
 #define RS_HOST_NAME          "HostName"
 #define RS_HOST               "Host"
 #define RS_SERVER             "Server"
+#define RS_SERVER_NAME        "Servername"
 #define RS_PORT_NUMBER        "PortNumber"
 #define RS_PORT               "Port"
 #define RS_DATABASE           "Database"


### PR DESCRIPTION
Tableau and other ODBC clients commonly use the Servername= keyword in DSN-less connection strings, but the driver only recognized HostName, Host, and Server. 

Upgrading from 1.x might break certain installations since the earlier major version of this package supported such a keyword.

Adds RS_SERVER_NAME ("Servername") to both the connection string parser and the DSN registry reader so all four keyword variants map to szHost correctly.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
