### PR TITLE
Fix missing return in handleFederatedNonIamConnection routing password connections into IAM auth

### DIFF
--- a/src/odbc/rsodbc/rsconnect.cpp
+++ b/src/odbc/rsodbc/rsconnect.cpp
@@ -3807,6 +3807,13 @@ static SQLRETURN handleFederatedNonIamConnection(RS_CONN_INFO* pConn) {
             return SQL_ERROR;
         }
     }
+
+    // Not a federated (IdC) plugin connection: nothing to do here.
+    // Falling off the end of a non-void function is undefined behavior and,
+    // under -O2, made the compiler drop the plugin-name check above, forcing
+    // every non-IAM (username/password) connection into the federated auth
+    // path (resulting in IAMConnectionError: MissingAuthenticationToken).
+    return SQL_SUCCESS;
 }
 
 /*====================================================================================================================================================*/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

`handleFederatedNonIamConnection()` in `src/odbc/rsodbc/rsconnect.cpp` is
declared to return `SQLRETURN`, but contains **no `return` statement on the
path where the connection is not using an IdC federated plugin**
(`Plugin_Name` ≠ `IdpTokenAuthPlugin` / `BrowserIdcAuthPlugin`):

```cpp
static SQLRETURN handleFederatedNonIamConnection(RS_CONN_INFO* pConn) {
    ...
    if (pIamProps && (pIamProps->szPluginName[0] != '\0') &&
        ((_stricmp(pIamProps->szPluginName, PLUGIN_IDP_TOKEN_AUTH) == 0) ||
         (_stricmp(pIamProps->szPluginName, PLUGIN_BROWSER_IDC_AUTH) == 0))) {
        ...
        return SQL_SUCCESS; /* or SQL_ERROR from catch blocks */
    }
}   // <-- control falls off the end of a non-void function: undefined behavior
```
As a result, every standard username/password connection is routed
through `RsIamHelper::NativePluginAuthentication` with an empty plugin name:

1. `SetIamSettings(false, ...)` takes its non-IAM branch.
2. `RsIamClient::Connect` finds no credential attributes and falls back to
   the default AWS credentials chain.
3. It calls the Redshift `GetClusterCredentials` API; with no AWS
   credentials on the host the request is unsigned, and the AWS endpoint
   rejects it with `MissingAuthenticationToken`.
4. The error surfaces as
   `[860:8:IAMConnectionError]: MissingAuthenticationToken: Missing Authentication Token`.

Logs:
Connecting with a plain username/password connection string — no `IAM`, no
`Plugin_Name`, no `AuthProfile` keywords — e.g. from Tableau on Linux:

```
DRIVER={Amazon Redshift (x64)};Servername=...;DATABASE=...;PORT=5439;UID=...;PWD=...;sslmode=require
```

fails with:

```
SQLState: HY000
[Redshift][ODBC Driver][Server][860:8:IAMConnectionError]: MissingAuthenticationToken: Missing Authentication Token
```

The connection never reaches the standard libpq (username/password) path.
Affects driver **v2.2.0 built from source with GCC at `-O2`/`-O3`** (Ubuntu
22.04, GCC 11 in our case).

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] I have read the **CONTRIBUTING** document [Currently not accepting contributions]-->
- [ ] Local run of `mvn install` succeeds
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
