### PR TITLE
fix: don't truncate szPassword to MAX_IDEN_LEN in SQLDriverConnect/DS…Fix: don't truncate long IAM passwords to `MAX_IDEN_LEN` in SQLDriverConnect/DSN parsing

### DIFF
--- a/src/odbc/rsodbc/rsconnect.cpp
+++ b/src/odbc/rsodbc/rsconnect.cpp
@@ -2326,9 +2326,17 @@ int RS_CONN_INFO::parseConnectString(char *szConnStrIn, size_t cbConnStrIn, int 
                         : SHORT_NAME_KEYWORD;
                 if (CAN_OVERRIDE_DSN ||
                     pConnectProps->szPassword[0] == '\0') {
+                    // Use the actual size of szPassword (PADB_MAX_PARAMETERS,
+                    // see RS_CONNECT_PROPS_INFO in rsodbc.h) instead of
+                    // MAX_IDEN_LEN, which is intended for identifier fields
+                    // (host/port/DSN/user) and is far smaller than IAM
+                    // temporary passwords returned by get-credentials
+                    // (up to ~2000+ chars). This matches the limit already
+                    // used by the SQLConnect path (RS_SQLConnect, above),
+                    // which does not truncate the same password.
                     strncpy(pConnectProps->szPassword, pval,
-                            MAX_IDEN_LEN - 1);
-                    pConnectProps->szPassword[MAX_IDEN_LEN - 1] = '\0';
+                            sizeof(pConnectProps->szPassword) - 1);
+                    pConnectProps->szPassword[sizeof(pConnectProps->szPassword) - 1] = '\0';
                 }
             } else if (_stricmp(pname, RS_DSN) == 0) {
                 if (CAN_OVERRIDE_DSN || pConnectProps->szDSN[0] == '\0') {
@@ -3198,7 +3206,11 @@ void RS_CONN_INFO::readMoreConnectPropsFromRegistry(int readUser)
             }
 
             if(pConnectProps->szPassword[0] == '\0') {
-              RS_SQLGetPrivateProfileString(pConnectProps->szDSN, RS_PASSWORD, "", pConnectProps->szPassword, MAX_IDEN_LEN, ODBC_INI);
+              // Use sizeof(szPassword) instead of MAX_IDEN_LEN here too, for
+              // the same reason as the SQLDriverConnect connect-string path
+              // above: MAX_IDEN_LEN is sized for identifiers, not for long
+              // IAM temporary passwords read from a DSN in odbc.ini.
+              RS_SQLGetPrivateProfileString(pConnectProps->szDSN, RS_PASSWORD, "", pConnectProps->szPassword, sizeof(pConnectProps->szPassword), ODBC_INI);
 #ifdef WIN32
 			  if (pConnectProps->szPassword[0] != '\0')
 			  {
@@ -3213,7 +3225,7 @@ void RS_CONN_INFO::readMoreConnectPropsFromRegistry(int readUser)
 			  }
 #endif
               if(pConnectProps->szPassword[0] == '\0') {
-                RS_SQLGetPrivateProfileString(pConnectProps->szDSN, RS_PWD, "", pConnectProps->szPassword, MAX_IDEN_LEN, ODBC_INI);
+                RS_SQLGetPrivateProfileString(pConnectProps->szDSN, RS_PWD, "", pConnectProps->szPassword, sizeof(pConnectProps->szPassword), ODBC_INI);
               }
             }
         }


### PR DESCRIPTION
## Description

Use `sizeof(pConnectProps->szPassword)` (`PADB_MAX_PARAMETERS`, 32767)
instead of `MAX_IDEN_LEN` (1024) as the copy limit for the password field, in
both places that populate it from something other than `SQLConnect`'s direct
argument:

- `parseConnectString()` — used by `SQLDriverConnect` to parse `PWD=`/`Password=`
  from the connection string.
- `readMoreConnectPropsFromRegistry()` — used to read `PWD`/`Password`
  directly from a DSN section in `odbc.ini`. This shares the same
  `MAX_IDEN_LEN` limit and the same bug pattern as the `SQLDriverConnect`
  case.

This matches the limit already used by the `SQLConnect` code path
(`RS_SQLConnect`), so both ODBC connect APIs now behave consistently for long
passwords.

## Motivation and Context

`SQLDriverConnect` (a connection string, with or without a `DSN=` keyword)
truncates the password to `MAX_IDEN_LEN - 1` (1024) characters before sending
it to the server. This breaks IAM authentication whenever
`aws redshift-serverless get-credentials` (or similar) returns a temporary
password longer than 1024 characters — which is common. The server then
rejects the truncated password with:

```
28000:FATAL:  IAM authentication failed for user "IAMR:<role>"
```

`SQLConnect` (DSN name + UID + PWD passed as three separate arguments) is
**not** affected, because that path already copies the password using
`sizeof(pConnectProps->szPassword)` as the limit. This inconsistency between
the two ODBC connect APIs is the root cause — see #46 for full details,
reproduction steps, and driver-log evidence.

This affects any client that connects via a connection string, including
Tableau Desktop.

Fixes #46

## Testing

Reproduced the original bug and verified the fix on:

| Environment | Client | Result |
|---|---|---|
| Linux (Amazon Linux 2023, x86_64), source build | `isql` (unixODBC), `SQLDriverConnect` | Fixed |
| Linux (Amazon Linux 2023, x86_64), source build | `isql` (unixODBC), `SQLConnect` | Unaffected (already worked) |
| macOS (Apple Silicon, arm64), source build | `isql` (unixODBC), `SQLDriverConnect` | Fixed |
| macOS (Apple Silicon, arm64) | Tableau Desktop (actual application) | Fixed |

In each case, driver logs (`fe-misc.c:232`, `LogLevel=6`) confirmed the exact
number of bytes sent to the backend now matches the full password length
(+1 for the NUL terminator), with no truncation:

| Environment | Password length | Bytes sent (before fix) | Bytes sent (after fix) |
|---|---|---|---|
| Linux | 2321 | ~1025 | 2322 |
| macOS | 1909 | ~1025 | 1910 |

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
